### PR TITLE
Fixes related to the updated Slack and Watson APIs and the location

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,8 +19,10 @@ location = "/Users/xxxxxxxx/Downloads/Movie_Bot/"  # replace with the full folde
 ######## Slack configuration   ##########################
 ###################################################################
 
+# note: create Slack App with classic 'bot' scope, https://api.slack.com/apps?new_classic_app=1
+# otherwise it will not work, see https://github.com/slackapi/python-slackclient/issues/584
 SLACK_BOT_TOKEN='xoxb-xxxxxxxxxxxx-xxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx'
-SLACK_VERIFICATION_TOKEN='xxxxxxxxxxxxxxxxxxxxxxxx' 
+SLACK_VERIFICATION_TOKEN='xxxxxxxxxxxxxxxxxxxxxxxx' # some applications might require bot verification, generally not necessary
 
 # instantiate Slack client
 slack_client = SlackClient(SLACK_BOT_TOKEN) # do not change this parameter
@@ -29,12 +31,14 @@ slack_client = SlackClient(SLACK_BOT_TOKEN) # do not change this parameter
 ######## Watson service configuration   ##########################
 ###################################################################
 
+# note: depending on your location you will need to set the AssistantV1 url parameter
+# e.g. in Germany you will need to set url='https://api.eu-de.assistant.watson.cloud.ibm.com'
 service = watson_developer_cloud.AssistantV1(
-    iam_api_key = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', # replace with Password
+    iam_apikey = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', # replace with Assistant API key
     version = '2018-09-20'
 )
 
-workspace_id = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' # replace with Assistant ID
+workspace_id = 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' # replace with Skill ID
 
 ###################################################################
 ######## Log files configuration   ##########################

--- a/nlp/IBM_Watson_Conversation_setup.ipynb
+++ b/nlp/IBM_Watson_Conversation_setup.ipynb
@@ -244,6 +244,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note: as of 2020-05-01 (EU) the API Key for the `config.py` file should be taken from the Assistant Settings API details. Depending on your location, you will also need part of the URL as parameter in your `AssistantV1()` function call. In addition, you will need from the Skill API details the Skill ID as `workspace_id`. Disclaimer: the selection of these parameters might depend on your location."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Step7 - Edit the config.py to add watson configuration"
    ]
   },

--- a/nlp/nlp_solutions/nlplearn.py
+++ b/nlp/nlp_solutions/nlplearn.py
@@ -11,6 +11,8 @@
 from nltk.tokenize import word_tokenize
 import re
 import nltk
+nltk.download('stopwords')
+nltk.download('punkt')
 from nltk.corpus import stopwords
 from sklearn.externals import joblib
 from sklearn.feature_extraction.text import TfidfVectorizer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas==0.20.3
+pandas==0.23.3
 slackclient==1.2.1
 watson-developer-cloud>=2.4.0
 tabulate==0.8.2

--- a/slack/Create_slack_app.ipynb
+++ b/slack/Create_slack_app.ipynb
@@ -32,7 +32,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Visit https://api.slack.com/apps to create a slack app. "
+    "Visit https://api.slack.com/apps to create a slack app. Note: you should create the Slack App with classic `bot` scope, and not with the new more granular scopes (otherwise it will not work, see this [github issue](https://github.com/slackapi/python-slackclient/issues/584)). In order to create such a classic app, use https://api.slack.com/apps?new_classic_app=1"
    ]
   },
   {
@@ -89,7 +89,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Click on the bot user features on the left panel of the app page and fill in the details. Please make sure to turn on the toggle option to show your bot always online. Once the details are provided, click \"Add Bot User\""
+    "The \"Bot Users\" feature is not anymore available on the left panel of the app page, but integrated in the \"App Home\" feature. Click on the \"App Home\" feature and fill in the details. Please make sure to turn on the toggle option to show your bot always online. Once the details are provided, click \"Add Bot User\""
    ]
   },
   {
@@ -154,7 +154,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Make a note of the __\"Bot User OAuth Access Token\"__. This token will be needed to access your slack app from python. Some application requires bot verification as well. This token can be found in \"Basic Information\" tab under \"App Credentials\" section\" as shown below."
+    "Make a note of the __\"Bot User OAuth Access Token\"__. This token will be needed to access your slack app from python. Some applications require bot verification as well. This token can be found in \"Basic Information\" tab under \"App Credentials\" section\" as shown below."
    ]
   },
   {


### PR DESCRIPTION
Several comments and minor changes are proposed in order to make the setup easier for the new user. The definition and content of the Slack tokens and the Watson IDs / keys have been updated, in order to work with present versions of the APIs. Further, more information about using Watson in different locations has been added. In this regard, some relevant comments have been included in the notebooks. In addition, the Pandas version has been updated to be compatible with Python 3.7. Finally, some required data (stop words, punkt tokenizer) are downloaded by default at the beginning to avoid errors related to the NLTK library.